### PR TITLE
Add tracker support for Piwik

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -267,13 +267,3 @@
               .submit_container
                 %input.button{ name: 'submit', type: 'submit', value: 'Abschicken' }
     %a.next-section.icons-top{ href: '#top' } Top
-:javascript
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-40536002-1']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-   var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-   ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-   })();

--- a/source/localizable/index.en.html.haml
+++ b/source/localizable/index.en.html.haml
@@ -241,13 +241,3 @@
               .submit_container
                 %input.button{ name: 'submit', type: 'submit', value: 'Abschicken' }
     %a.next-section.icons-top{ href: '#top' } Top
-:javascript
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-40536002-1']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-   var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-   ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-   })();

--- a/source/pantalk-rms.html.haml
+++ b/source/pantalk-rms.html.haml
@@ -28,19 +28,8 @@ layout: false
     = stylesheet_link_tag 'rms'
 
     = javascript_include_tag 'rms'
+    = partial 'partials/piwik'
 
-    :javascript
-      // Piwik
-      var _paq = _paq || [];
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function() {
-        var u="//piwik-panter.rhcloud.com/";
-        _paq.push(['setTrackerUrl', u+'piwik.php']);
-        _paq.push(['setSiteId', 3]);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-      })();
   %body
     #banner.visible-md-block.visible-lg-block.hidden-xs
       %h2#author Richard Stallman

--- a/source/pantalk-rms.html.haml
+++ b/source/pantalk-rms.html.haml
@@ -29,6 +29,18 @@ layout: false
 
     = javascript_include_tag 'rms'
 
+    :javascript
+      // Piwik
+      var _paq = _paq || [];
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//piwik-panter.rhcloud.com/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 3]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
   %body
     #banner.visible-md-block.visible-lg-block.hidden-xs
       %h2#author Richard Stallman

--- a/source/partials/_analytics.html.haml
+++ b/source/partials/_analytics.html.haml
@@ -1,0 +1,10 @@
+:javascript
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-40536002-1']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+   var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+   ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+   })();

--- a/source/partials/_header.html.haml
+++ b/source/partials/_header.html.haml
@@ -20,3 +20,13 @@
   %link{:href => "/apple-touch-icon-precomposed.png", :rel => "apple-touch-icon"}/
 
   = stylesheet_link_tag 'application'
+  :javascript
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-40536002-1']);
+    _gaq.push(['_trackPageview']);
+
+    (function() {
+     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+     })();

--- a/source/partials/_header.html.haml
+++ b/source/partials/_header.html.haml
@@ -20,25 +20,5 @@
   %link{:href => "/apple-touch-icon-precomposed.png", :rel => "apple-touch-icon"}/
 
   = stylesheet_link_tag 'application'
-  :javascript
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', 'UA-40536002-1']);
-    _gaq.push(['_trackPageview']);
-
-    (function() {
-     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-     })();
-
-     // Piwik
-     var _paq = _paq || [];
-     _paq.push(['trackPageView']);
-     _paq.push(['enableLinkTracking']);
-     (function() {
-       var u="//piwik-panter.rhcloud.com/";
-       _paq.push(['setTrackerUrl', u+'piwik.php']);
-       _paq.push(['setSiteId', 3]);
-       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-       g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-     })();
+  = partial 'partials/analytics'
+  = partial 'partials/piwik'

--- a/source/partials/_header.html.haml
+++ b/source/partials/_header.html.haml
@@ -30,3 +30,15 @@
      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
      })();
+
+     // Piwik
+     var _paq = _paq || [];
+     _paq.push(['trackPageView']);
+     _paq.push(['enableLinkTracking']);
+     (function() {
+       var u="//piwik-panter.rhcloud.com/";
+       _paq.push(['setTrackerUrl', u+'piwik.php']);
+       _paq.push(['setSiteId', 3]);
+       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+       g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+     })();

--- a/source/partials/_piwik.html.haml
+++ b/source/partials/_piwik.html.haml
@@ -1,0 +1,12 @@
+:javascript
+   // Piwik
+   var _paq = _paq || [];
+   _paq.push(['trackPageView']);
+   _paq.push(['enableLinkTracking']);
+   (function() {
+     var u="//piwik-panter.rhcloud.com/";
+     _paq.push(['setTrackerUrl', u+'piwik.php']);
+     _paq.push(['setSiteId', 3]);
+     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+   })();

--- a/source/recomy-best-of-swiss-web-2014.html.erb
+++ b/source/recomy-best-of-swiss-web-2014.html.erb
@@ -171,5 +171,18 @@ inhabergeführt und Initiantin von Colab Zurich.</p>
        })();
 
      </script>
+     <script type="text/javascript">
+       // Piwik
+       var _paq = _paq || [];
+       _paq.push(['trackPageView']);
+       _paq.push(['enableLinkTracking']);
+       (function() {
+         var u="//piwik-panter.rhcloud.com/";
+         _paq.push(['setTrackerUrl', u+'piwik.php']);
+         _paq.push(['setSiteId', 3]);
+         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+       })();
+     </script>
    </body>
  </html>

--- a/source/recomy-best-of-swiss-web-2014.html.erb
+++ b/source/recomy-best-of-swiss-web-2014.html.erb
@@ -158,31 +158,7 @@ inhabergeführt und Initiantin von Colab Zurich.</p>
           <p><a target="_blank" href="http://panter.ch">www.panter.ch</a></p>
         </div>
       </div>
-    <script type="text/javascript">
-
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-40536002-1']);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-       var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-       ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-       })();
-
-     </script>
-     <script type="text/javascript">
-       // Piwik
-       var _paq = _paq || [];
-       _paq.push(['trackPageView']);
-       _paq.push(['enableLinkTracking']);
-       (function() {
-         var u="//piwik-panter.rhcloud.com/";
-         _paq.push(['setTrackerUrl', u+'piwik.php']);
-         _paq.push(['setSiteId', 3]);
-         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-       })();
-     </script>
+      <%= partial 'partials/analytics' %>
+      <%= partial 'partials/piwik' %>
    </body>
  </html>


### PR DESCRIPTION
While we do not use Google Analytics on the RMS page to respect his
privacy preferences, we do use Piwik for this page. Piwik is free/libre
software and we do not share it's result with other companies. It's also
configured to respect the users privacy by anonymizing and watching the
'do not track' setting.
